### PR TITLE
Update node-sonos

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,11 @@ RUN export USER=root && npm install -g --unsafe-perm babel@5
 
 ADD supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
-RUN git clone https://github.com/stephen/airsonos && cd airsonos && git reset --hard 50d70ce && export USER=root && npm install -g --unsafe-perm
+RUN git clone https://github.com/stephen/airsonos && \
+    cd airsonos && \
+    sed -i 's|stephen/node-sonos.git#stephen-1.0.0|paixaop/node-sonos|' package.json && \
+    export USER=root && \
+    npm install -g --unsafe-perm
 
 RUN chmod +x /build/dbus.sh
 


### PR DESCRIPTION
The version of node-sonons from stephen/node-sonos wasn't working with the my Sonos speakers, and stephen/airsonos#216 described the problem to a tee. This is fixed in paixaop/node-sonos. Also note that paixaop has been waiting for his work to be merged in stephen/node-sonos#5 but it appears to be stalled.

This commit has been tested on a pi3 using a raspbian image with docker installed from dockerproject's raspbian-jesse repo.
